### PR TITLE
Use NullLogger in SymfonyControllerKernel

### DIFF
--- a/tests/Controller/SymfonyControllerTest.php
+++ b/tests/Controller/SymfonyControllerTest.php
@@ -7,6 +7,7 @@ namespace Chaos\Monkey\Symfony\Tests\Controller;
 use Chaos\Monkey\Settings;
 use Chaos\Monkey\Symfony\ChaosMonkeyBundle;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
@@ -109,6 +110,8 @@ class SymfonyControllerKernel extends Kernel
         $c->extension('framework', [
             'secret' => 'S0ME_SECRET',
         ]);
+
+        $c->services()->set('logger', NullLogger::class);
     }
 
     protected function configureRoutes(RoutingConfigurator $routes)


### PR DESCRIPTION
Due to exception attack test there was an error reported to output by symfony's logger, so I've decided to silence that kernel 😎.

```
.[critical] Uncaught PHP Exception RuntimeException: "" at .../chaos-monkey-symfony-bundle/vendor/chaos-php/chaos-monkey/src/Assault/ExceptionAssault.php line 27

.                                     2 / 2 (100%)
```

->

```
..                                    2 / 2 (100%)
```